### PR TITLE
model.dataset: fix indentation error

### DIFF
--- a/model/dataset.py
+++ b/model/dataset.py
@@ -111,7 +111,8 @@ class YOLO1DDataset(torch.utils.data.Dataset):
                 elif not anchor_taken and iou_anchors[idx] > self.ignore_iou_thresh:
                     # ignore prediction by setting objectness to -1
                     targets[scale_idx][anchor_on_scale, x_cell, 0] = -1
-            return series, tuple(targets)
+        return series, tuple(targets)
+
 
 if __name__ == "__main__":
     # simple unittests


### PR DESCRIPTION
Fix incorrectly indented return of Dataset.__getitem__ which was previously inside a for loop loping over anchor_indices, thereby not allowing the loop over all anchor indices. This caused an issue where targets with multiple labels were only returned with one label due to the early exit of the loop, since all the targets are assigned to one of the anchor boxes but only one anchor box could be assigned.

closes #30