### PR TITLE
model.dataset: Fix typo and add copy

### DIFF
--- a/model/dataset.py
+++ b/model/dataset.py
@@ -72,9 +72,9 @@ class YOLO1DDataset(torch.utils.data.Dataset):
             # self.transform:
             # takes 1D series and bboxes
             # outputs transformed
-            augmetnations = self.transorm(series=series, bboxes=bboxes)
-            series = augmetnations["series"]
-            bboxes = augmetnations["bboxes"]
+            augmentations = self.transform(series=series, bboxes=bboxes)
+            series = augmentations["series"].copy()
+            bboxes = augmentations["bboxes"]
 
         # Target specification
         # target has size


### PR DESCRIPTION
Fixes a typo (name only, not leading to errors).

Also makes a copy of series when an augmentation is applied. This is needed when the flip augmentation is applied as it introduces negative stride, which is not supported in PyTorch. It might actually be better in the future to add copy only when applying the flip transformation however. This is a catch-all solution but might be a bit less memory efficient.