### PR TITLE
45 make anchor per scale an option

### DIFF
--- a/model/dataset.py
+++ b/model/dataset.py
@@ -14,6 +14,7 @@ class YOLO1DDataset(torch.utils.data.Dataset):
                  transform=None,
                  ignore_io_thresh = 0.5,
                  one_anchor_per_scale=False,
+                 return_bboxes=False,
                  *args, **kwargs
                  ):
         """YOLO Dataset class
@@ -47,6 +48,7 @@ class YOLO1DDataset(torch.utils.data.Dataset):
         self.num_classes = num_classes
         self.ignore_iou_thresh = ignore_io_thresh
         self._one_anchor_per_scale = one_anchor_per_scale
+        self.return_bboxes = return_bboxes
 
     def __len__(self):
         return len(self.annotations)
@@ -77,6 +79,9 @@ class YOLO1DDataset(torch.utils.data.Dataset):
             augmentations = self.transform(series=series, bboxes=bboxes)
             series = augmentations["series"].copy()
             bboxes = augmentations["bboxes"]
+
+        if self.return_bboxes:
+            return series, bboxes
 
         # Target specification
         # define a target vector [obj, x, w, class]


### PR DESCRIPTION
Adds the following changes:
+ Makes `anchor_on_scale` check in target creation togglable by the `Dataset` `one_bbox_per_scale` option. Removing this check (i.e. setting `one_bbox_per_scale` to False) has produced improved objectness confidence, network recall and precision. (*) 
+ Adds `return_bboxes` to `Dataset` such that the dataset can also return the target label instead of the loss target. This is more usefull for visualization purposes while not training the network (the loss targets are only required during learning, and should perhaps be moved to the loss function alltogether).

(*) It is not entirely certain why, but my suspicion is that we were assigining targets to unsuitable anchors, thereby reducing the IOU with target labels in the loss function and down-weighting the networks ability to assign a 1 to the objectness class (this is kind of detailed byt 